### PR TITLE
Fix initialScore and finalScore (#37)

### DIFF
--- a/BeatSaberHTTPStatus/GameStatus.cs
+++ b/BeatSaberHTTPStatus/GameStatus.cs
@@ -58,6 +58,7 @@ namespace BeatSaberHTTPStatus {
 		public bool wasCutTooSoon = false;
 		public int initialScore = -1;
 		public int finalScore = -1;
+		public int cutDistanceScore = -1;
 		public int cutMultiplier = 0;
 		public float saberSpeed = 0;
 		public float saberDirX = 0;
@@ -155,6 +156,7 @@ namespace BeatSaberHTTPStatus {
 			this.wasCutTooSoon = false;
 			this.initialScore = -1;
 			this.finalScore = -1;
+			this.cutDistanceScore = -1;
 			this.cutMultiplier = 0;
 			this.saberSpeed = 0;
 			this.saberDirX = 0;

--- a/BeatSaberHTTPStatus/Plugin.cs
+++ b/BeatSaberHTTPStatus/Plugin.cs
@@ -325,14 +325,15 @@ namespace BeatSaberHTTPStatus {
 
 			SetNoteCutStatus(noteData, noteCutInfo, true);
 
-			int score = 0;
-			int afterScore = 0;
+			int beforeCutScore = 0;
+			int afterCutScore = 0;
 			int cutDistanceScore = 0;
 
-			ScoreModel.RawScoreWithoutMultiplier(noteCutInfo, out score, out afterScore, out cutDistanceScore);
+			ScoreModel.RawScoreWithoutMultiplier(noteCutInfo, out beforeCutScore, out afterCutScore, out cutDistanceScore);
 
-			gameStatus.initialScore = score;
+			gameStatus.initialScore = beforeCutScore + cutDistanceScore;
 			gameStatus.finalScore = -1;
+			gameStatus.cutDistanceScore = cutDistanceScore;
 			gameStatus.cutMultiplier = multiplier;
 
 			if (noteData.noteType == NoteType.Bomb) {
@@ -368,8 +369,8 @@ namespace BeatSaberHTTPStatus {
 		}
 
 		public void OnNoteWasFullyCut(CutScoreBuffer acsb) {
-			int score;
-			int afterScore;
+			int beforeCutScore;
+			int afterCutScore;
 			int cutDistanceScore;
 
 			NoteCutInfo noteCutInfo = (NoteCutInfo) noteCutInfoField.GetValue(acsb);
@@ -380,12 +381,13 @@ namespace BeatSaberHTTPStatus {
 			SetNoteCutStatus(noteData, noteCutInfo, false);
 
 			// public static ScoreModel.RawScoreWithoutMultiplier(NoteCutInfo, out int beforeCutRawScore, out int afterCutRawScore, out int cutDistanceRawScore)
-			ScoreModel.RawScoreWithoutMultiplier(noteCutInfo, out score, out afterScore, out cutDistanceScore);
+			ScoreModel.RawScoreWithoutMultiplier(noteCutInfo, out beforeCutScore, out afterCutScore, out cutDistanceScore);
 
 			int multiplier = (int) cutScoreBufferMultiplierField.GetValue(acsb);
 
-			statusManager.gameStatus.initialScore = score;
-			statusManager.gameStatus.finalScore = score + afterScore;
+			statusManager.gameStatus.initialScore = beforeCutScore + cutDistanceScore;
+			statusManager.gameStatus.finalScore = beforeCutScore + afterCutScore + cutDistanceScore;
+			statusManager.gameStatus.cutDistanceScore = cutDistanceScore;
 			statusManager.gameStatus.cutMultiplier = multiplier;
 
 			statusManager.EmitStatusUpdate(ChangedProperties.PerformanceAndNoteCut, "noteFullyCut");

--- a/BeatSaberHTTPStatus/StatusManager.cs
+++ b/BeatSaberHTTPStatus/StatusManager.cs
@@ -133,6 +133,7 @@ namespace BeatSaberHTTPStatus {
 			_noteCutJSON["wasCutTooSoon"] = gameStatus.wasCutTooSoon;
 			_noteCutJSON["initialScore"] = gameStatus.initialScore == -1 ? (JSONNode) JSONNull.CreateOrGet() : (JSONNode) new JSONNumber(gameStatus.initialScore);
 			_noteCutJSON["finalScore"] = gameStatus.finalScore == -1 ? (JSONNode) JSONNull.CreateOrGet() : (JSONNode) new JSONNumber(gameStatus.finalScore);
+			_noteCutJSON["cutDistanceScore"] = gameStatus.cutDistanceScore == -1 ? (JSONNode) JSONNull.CreateOrGet() : (JSONNode) new JSONNumber(gameStatus.cutDistanceScore);
 			_noteCutJSON["swingRating"] = gameStatus.swingRating;
 			_noteCutJSON["multiplier"] = gameStatus.cutMultiplier;
 			_noteCutJSON["saberSpeed"] = gameStatus.saberSpeed;

--- a/protocol.md
+++ b/protocol.md
@@ -116,8 +116,9 @@ NoteCutObject = {
 	"directionOK": null | Boolean, // Note was cut in the correct direction. null for bombs.
 	"saberTypeOK": null | Boolean, // Note was cut with the correct saber. null for bombs.
 	"wasCutTooSoon": Boolean, // Note was cut too early
-	"initalScore": null | Integer, // Score without multipliers for the cut. Doesn't include the score for swinging after cut. null for bombs.
-	"finalScore": null | Integer, // Score without multipliers for the entire cut, including score for swinging after cut. Available in [`noteFullyCut` event](#notefullycut-event). null for bombs.
+	"initalScore": null | Integer, // Score without multipliers for the cut. It contains the prehit swing score and the cutDistanceScore, but doesn't include the score for swinging after cut. [0..85] null for bombs.
+	"finalScore": null | Integer, // Score without multipliers for the entire cut, including score for swinging after cut. [0..115] Available in [`noteFullyCut` event](#notefullycut-event). null for bombs.
+	"cutDistanceScore": null | Integer, // Score for the hit itself. [0..15] 
 	"multiplier": Integer, // Combo multiplier at the time of cut
 	"saberSpeed": Number, // Speed of the saber when the note was cut
 	"saberDir": [ // Direction the saber was moving in when the note was cut


### PR DESCRIPTION
The `cutDistanceScore` was not included in the `initialScore` and `finalScore`.

* Fix initialScore and finalScore calculation (fixes #37)
* Expose cutDistanceScore
* Included cutDistanceScore in protocol.md